### PR TITLE
1.16.5 Support

### DIFF
--- a/1.16.1/build.gradle
+++ b/1.16.1/build.gradle
@@ -20,7 +20,7 @@ plugins {
     id 'fabric-loom' version '0.5-SNAPSHOT'
 }
 
-project.ext.set("customVer", "1.16.4")
+project.ext.set("customVer", "1.16.5")
 
 apply plugin: 'java'
 apply from: '../../mod/common.gradle'

--- a/1.16.1/gradle.properties
+++ b/1.16.1/gradle.properties
@@ -16,7 +16,7 @@
 # along with The 5zig Mod.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-minecraft_version=1.16.4
-yarn_mappings=1.16.4+build.7
-loader_version=0.10.8
-fabric_version=0.27.1+1.16
+minecraft_version=1.16.5
+yarn_mappings=1.16.5+build.3
+loader_version=0.11.1
+fabric_version=0.29.4+1.16


### PR DESCRIPTION
This will add 1.16.5 support. There were no significant changes in this version for Fabric and I have not seen anything broken.